### PR TITLE
cloud_camera: fix issue #6

### DIFF
--- a/src/gpg/cloud_camera.cpp
+++ b/src/gpg/cloud_camera.cpp
@@ -395,7 +395,7 @@ void CloudCamera::calculateNormalsOrganized()
   ne.setNormalEstimationMethod(ne.COVARIANCE_MATRIX);
   ne.setNormalSmoothingSize(20.0f);
   ne.compute(*cloud_normals);
-  normals_ = cloud_normals->getMatrixXfMap().cast<double>();
+  normals_ = cloud_normals->getMatrixXfMap(3, sizeof(pcl::Normal)/sizeof(float), 0).cast<double>();
 }
 
 


### PR DESCRIPTION
Added parameters to specify the number of dimensions to consider for
each point, When invoking pcl::PointCloud< PointT >::getMatrixXfMap()

Signed-off-by: Sharron LIU <sharron.liu@intel.com>